### PR TITLE
Update README.md example dockerfile run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you created a container image based on a dockerfile like the following:
 cat Dockerfile
 FROM fedora:latest
 ENV container docker
-RUN dnf -y install httpd; dnf clean all; systemctl enable httpd; systemctl disable dnf* dnf-makecache.timer
+RUN dnf -y install httpd; dnf -y update; dnf clean all; systemctl enable httpd; systemctl disable dnf-makecache.timer dnf-makecache.service
 CMD [ "/sbin/init" ]
 ```
 


### PR DESCRIPTION
Wildcard 'dnf-*' service causes failure to build.  Explicitly list
dnf-makecache.service instead.  Also update the base image, in case
newer base image breaks example build in some other way.

Signed-off-by: Chris Evich <cevich@redhat.com>