### PR TITLE
Fix segment fault

### DIFF
--- a/src/systemdhook.c
+++ b/src/systemdhook.c
@@ -686,7 +686,7 @@ int main(int argc, char *argv[])
 	char *id = YAJL_GET_STRING(v_id);
 
 	const char *ctr = getenv("container");
-	if (!strncmp(ctr, DOCKER_CONTAINER, strlen(DOCKER_CONTAINER))) {
+	if (ctr && !strncmp(ctr, DOCKER_CONTAINER, strlen(DOCKER_CONTAINER))) {
 		docker = true;
 	}
 


### PR DESCRIPTION
If env "container" not set, this program will report segment fault when
executed, this is caused by `strncmp(NULL, ...)`.

Adding a judgement of NULL can avoid this.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>