### PR TITLE
We should not be mounting /run and /tmp as NOEXEC

### DIFF
--- a/src/systemdhook.c
+++ b/src/systemdhook.c
@@ -442,7 +442,7 @@ static int prestart(const char *rootfs,
 		}
 
 		/* Mount tmpfs at new temp directory */
-		if (mount("tmpfs", run_tmp_dir, "tmpfs", MS_NODEV|MS_NOSUID|MS_NOEXEC, options) == -1) {
+		if (mount("tmpfs", run_tmp_dir, "tmpfs", MS_NODEV|MS_NOSUID, options) == -1) {
 			pr_perror("Failed to mount tmpfs at %s", run_tmp_dir);
 			return -1;
 		}


### PR DESCRIPTION
The defaults on the host system are /run and /tmp do not run with
NOEXEC, so we should not change the default inside of a container.
This is breaking certain workloads.