### PR TITLE
Touch up a minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ CMD [ "/sbin/init" ]
 You should then be able to execute the following commands:
 
 ```
-docker build –t httpd .
+docker build -t httpd .
 docker run -ti --stop-signal=RTMIN+3 httpd
 ```
 


### PR DESCRIPTION
The docker build had a weird dash in it, I'm not sure how it got there.  If cut/pasted the command would fail.  I've removed the bad dash and have replaced it with a valid one.