### PR TITLE
improve error message if no 'bundlePath' in stateData

### DIFF
--- a/src/systemdhook.c
+++ b/src/systemdhook.c
@@ -706,8 +706,11 @@ int main(int argc, char *argv[])
 	const char *bundle_path[] = { "bundlePath", (const char *)0 };
 	yajl_val v_bundle_path = yajl_tree_get(node, bundle_path, yajl_t_string);
 	if (v_bundle_path) {
-		sprintf(config_file_name, "%s/config.json", YAJL_GET_STRING(v_bundle_path));
+		snprintf(config_file_name, PATH_MAX, "%s/config.json", YAJL_GET_STRING(v_bundle_path));
 		fp = fopen(config_file_name, "r");
+	} else {
+		char msg[] = "bundlePath not found in state";
+		snprintf(config_file_name, PATH_MAX, "%s", msg);
 	}
 
 	/* Parse the config file */


### PR DESCRIPTION
systemdhook exits through the same error handling code path if it fails
to open the config file or if the config file name is not specified via
'bundlePath' in stateData. This patch ensures that the latter error is
reported explicitly:

  Failed to open config file: bundlePath not found in state

Also, call snprintf() to fill the 'config_file_name' buffer instead of
sprintf() for better protection against buffer overflow.