### PR TITLE
refactor reading state and config data

### DIFF
--- a/src/systemdhook.c
+++ b/src/systemdhook.c
@@ -781,8 +781,7 @@ int main(int argc, char *argv[])
 	}
 	char *id = YAJL_GET_STRING(v_id);
 
-	/* bundle_path must be specified for the OCI hooks, and from there we read the configuration file.
-	   If it is not specified, then check that it is specified on the command line.  */
+	/* 'bundlePath' must be specified for the OCI hooks, and from there we read the configuration file */
 	const char *bundle_path[] = { "bundlePath", (const char *)0 };
 	yajl_val v_bundle_path = yajl_tree_get(node, bundle_path, yajl_t_string);
 	if (v_bundle_path) {

--- a/src/systemdhook.c
+++ b/src/systemdhook.c
@@ -706,6 +706,11 @@ char *getJSONstring(FILE *from, size_t chunksize, char *msg)
 			}
 		}
 
+		if (bufsize == 0) {
+			err = "is empty";
+			goto fail;
+		}
+
 		JSONstring = (char *)realloc((void *)JSONstring, bufsize + 1);
 		if (JSONstring == NULL) {
 			err = "failed to allocate buffer";

--- a/src/systemdhook.c
+++ b/src/systemdhook.c
@@ -737,16 +737,14 @@ int main(int argc, char *argv[])
 	char config_file_name[PATH_MAX];
 	_cleanup_fclose_ FILE *fp = NULL;
 
-	memset(errbuf, 0, BUFLEN);
-
 	/* Read the entire state from stdin */
-	stateData = getJSONstring(stdin, (size_t)CHUNKSIZE, "state data");
-	if (stateData == NULL) {
-		pr_perror("failed to read state data from standard input");
+	snprintf(errbuf, BUFLEN, "failed to read state data from standard input");
+	stateData = getJSONstring(stdin, (size_t)CHUNKSIZE, errbuf);
+	if (stateData == NULL)
 		return EXIT_FAILURE;
-	}
 
 	/* Parse the state */
+	memset(errbuf, 0, BUFLEN);
 	node = yajl_tree_parse((const char *)stateData, errbuf, sizeof(errbuf));
 	if (node == NULL) {
 		pr_perror("parse_error: ");
@@ -801,13 +799,13 @@ int main(int argc, char *argv[])
 	}
 
 	/* Read the entire config file */
-	configData = getJSONstring(fp, (size_t)CHUNKSIZE, "config data");
-	if (configData == NULL) {
-		pr_perror("failed to read config data from %s", config_file_name);
+	snprintf(errbuf, BUFLEN, "failed to read config data from %s", config_file_name);
+	configData = getJSONstring(fp, (size_t)CHUNKSIZE, errbuf);
+	if (configData == NULL)
 		return EXIT_FAILURE;
-	}
 
 	/* Parse the config file */
+	memset(errbuf, 0, BUFLEN);
 	config_node = yajl_tree_parse((const char *)configData, errbuf, sizeof(errbuf));
 	if (config_node == NULL) {
 		pr_perror("parse_error: ");


### PR DESCRIPTION
This pull request consists of three commits:
1. introduce the getJSONstring() function
2. call getJSONstring() to read state data from standard input
3. call getJSONstring() to read config data from bundlePath/config.json
