### PR TITLE
Use env variable to disable oci-systemd-hook

### DIFF
--- a/src/systemdhook.c
+++ b/src/systemdhook.c
@@ -854,6 +854,37 @@ int main(int argc, char *argv[])
 		pr_perror("args not found in config");
 		return EXIT_FAILURE;
 	}
+
+	const char *envs[] = {"process", "env", (const char *)0 };
+	yajl_val v_envs = yajl_tree_get(config_node, envs, yajl_t_array);
+	if (v_envs) {
+		for (unsigned int i = 0; i < YAJL_GET_ARRAY(v_envs)->len; i++) {
+			yajl_val v_env = YAJL_GET_ARRAY(v_envs)->values[i];
+			char *str = YAJL_GET_STRING(v_env);
+			/****
+			* If the oci-systemd-hook variable is passed with "disabled", 
+			* stop execution of oci-systemd-hook.
+			******/
+			if (strncmp (str, "oci-systemd-hook=", strlen ("oci-systemd-hook=")) == 0) {
+				int valStart = strlen(str) - strlen("disabled");
+				if (strcasecmp(&str[valStart], "disabled") == 0) {
+					return EXIT_SUCCESS;
+				}
+			}
+			if (strncmp (str, "container_uuid=", strlen ("container_uuid=")) == 0) {
+				id = strdup (str + strlen ("container_uuid="));
+				/* systemd expects $container_uuid= to be an UUID but then treat it as
+					not containing any '-'.  Do the same here.  */
+				char *to = id;
+				for (char *from = to; *from; from++) {
+					if (*from != '-')
+						*to++ = *from;
+				}
+					*to = '\0';
+			}
+		}
+	}
+
 #if ARGS_CHECK
 	char *cmd = NULL;
 	yajl_val v_arg0_value = YAJL_GET_ARRAY(v_args)->values[0];
@@ -908,26 +939,6 @@ int main(int argc, char *argv[])
 			return EXIT_FAILURE;
 		}
 		config_mounts[i] = YAJL_GET_STRING(v_destination);
-	}
-
-	const char *envs[] = {"process", "env", (const char *)0 };
-	yajl_val v_envs = yajl_tree_get(config_node, envs, yajl_t_array);
-	if (v_envs) {
-		for (unsigned int i = 0; i < YAJL_GET_ARRAY(v_envs)->len; i++) {
-			yajl_val v_env = YAJL_GET_ARRAY(v_envs)->values[i];
-			char *str = YAJL_GET_STRING(v_env);
-			if (strncmp (str, "container_uuid=", strlen ("container_uuid=")) == 0) {
-				id = strdup (str + strlen ("container_uuid="));
-				/* systemd expects $container_uuid= to be an UUID but then treat it as
-				   not containing any '-'.  Do the same here.  */
-				char *to = id;
-				for (char *from = to; *from; from++) {
-					if (*from != '-')
-						*to++ = *from;
-				}
-				*to = '\0';
-			}
-		}
 	}
 
 	/* OCI hooks set target_pid to 0 on poststop, as the container process


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Introduces a variable to pass with the docker run command to turn off the use of oci-systemd-hook.   When issuing the "docker run" command, the following command would be used to disable the hook:

docker run --env oci-systemd-hook=DISABLED

If disabled is not the value (any case) or the variable is not set, hook continues as normal. 