### PR TITLE
Add preinstall instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,32 @@ journalctl -M CONTAINER_UUID
 
 To build, install, clean-up:
 
-First, **clone** this branch, then:
+Prior to installing oci-systemd-hook, install the following packages on your linux distro:
+
+* autoconf
+* automake
+* gcc
+* git 
+* go-md2man
+* libmount-devel
+* libselinux-devel
+* yajl-devel 
+
+In Fedora, you can use this command:
+
+```
+ dnf -y install \
+    autoconf \
+    automake \
+    gcc \
+    git \
+    go-md2man \
+    libmount-devel \
+    libselinux-devel \
+    yajl-devel
+```
+
+Then **clone** this branch and follow these steps:
 
 ```
 git clone https://github.com/projectatomic/oci-systemd-hook


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Adding the necessary packages to build oci-systemd-hook to the README.md file, much in the same manner as Buildah.   It's nice to have the list in advance rather than trying to figure out what's missing with each configure/make failure.