### PR TITLE
Allow container definitions where rootfs is not an absolute path

### DIFF
--- a/src/systemdhook.c
+++ b/src/systemdhook.c
@@ -879,6 +879,18 @@ int main(int argc, char *argv[])
 	}
 	char *rootfs = YAJL_GET_STRING(v_root);
 
+	/* Prepend bundle path if the rootfs string is relative */
+	if (rootfs[0] != '/') {
+		char *new_rootfs;
+
+		asprintf(&new_rootfs, "%s/%s", YAJL_GET_STRING(v_bundle_path), rootfs);
+		if (!new_rootfs) {
+			pr_perror("failed to alloc rootfs");
+			return EXIT_FAILURE;
+		}
+		rootfs = new_rootfs;
+	}
+
 	pr_pdebug("rootfs=%s", rootfs);
 	const char **config_mounts = NULL;
 	unsigned config_mounts_len = 0;


### PR DESCRIPTION
In earlier versions of the runc frame work the rootfs path was passed
as a key with the initial json that was passed on the stdin and it was
automatically computed to be an absolute path.

This translation to an absolute path must be done in the hook based on
the bundlePath.  This allows the config.json to be relocated by the
container hosting system storage without modifying the config.json.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>