### PR TITLE
Debian expects /run/lock to be a tmpfs as well as /run

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([OCI Systemd Hook], 0.1.11)
+AC_INIT([OCI Systemd Hook], 0.1.12)
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror subdir-objects])

--- a/src/systemdhook.c
+++ b/src/systemdhook.c
@@ -439,6 +439,11 @@ static int prestart(const char *rootfs,
 		return rc;
 	}
 
+	rc = move_mounts(rootfs, "/run/lock", config_mounts, config_mounts_len, uid, gid, options);
+	if (rc < 0) {
+		return rc;
+	}
+
 	_cleanup_free_ char *memory_cgroup_path = NULL;
 	memory_cgroup_path = get_process_cgroup_subsystem_path(pid, "memory");
 	if (!memory_cgroup_path) {


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>