### PR TITLE
Add support for hooks json configuration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,19 +8,24 @@ oci_systemd_hook_LDADD += $(SELINUX_LIBS)
 oci_systemd_hook_CFLAGS += $(LIBMOUNT_CFLAGS)
 oci_systemd_hook_LDADD += $(LIBMOUNT_LIBS)
 
+oci_systemd_hook_json_DATA = oci-systemd-hook.json
+oci_systemd_hook_jsondir=/usr/share/containers/oci/hooks.d
+
 dist_man_MANS = oci-systemd-hook.1
 EXTRA_DIST = README.md LICENSE
 
 oci-systemd-hook.1: doc/oci-systemd-hook.1.md
 	go-md2man -in doc/oci-systemd-hook.1.md -out oci-systemd-hook.1
 
-dist: oci-systemd-hook.spec 
+distrib: oci-systemd-hook.spec 
 	spectool -g oci-systemd-hook.spec
 
-rpm: dist
+rpm: distrib
 	rpmbuild --define "_sourcedir `pwd`" --define "_specdir `pwd`" \
 	--define "_rpmdir `pwd`" --define "_srcrpmdir `pwd`" -ba oci-systemd-hook.spec 
 
+install-data-local:
+	$(MKDIR_P) $(DESTDIR)$(oci_systemd_hook_jsondir)
 clean-local:
 	-rm -f oci-systemd-hook.1 *~
 	-rm -f oci-systemd-hook-*.tar.gz

--- a/oci-systemd-hook.json
+++ b/oci-systemd-hook.json
@@ -1,0 +1,5 @@
+{
+    "cmd": [".*/init$" , ".*/systemd$" ],
+    "hook": "/usr/libexec/oci/hooks.d/oci-systemd-hook",
+    "stages": [ "prestart", "poststop" ]
+}

--- a/oci-systemd-hook.spec
+++ b/oci-systemd-hook.spec
@@ -9,7 +9,7 @@
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 
 Name:           oci-systemd-hook
-Version:        0.1.4
+Version:        0.1.5
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        OCI systemd hook for docker
 Group:          Applications/Text
@@ -47,8 +47,14 @@ make %{?_smp_mflags}
 %license LICENSE
 %dir /%{_libexecdir}/oci
 %dir /%{_libexecdir}/oci/hooks.d
+%dir %{_usr}/share/containers/oci/hooks.d
+%{_usr}/share/containers/oci/hooks.d/oci-register-machine.json
 
 %changelog
+* Wed Sep 13 2017 Dan Walsh <dwalsh@redhat.com> - 0.1.5-1.gitde345df
+- Add support for json configuration to identify when to use hook
+- Needed for crio package
+
 * Thu Feb 18 2016 Dan Walsh <dwalsh@redhat.com> - 0.1.4-1.gitde345df
 - Fix up to prepare for review
 


### PR DESCRIPTION
This will allow container runtimes like crio to only
execute hooks when needed

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>