### PR TITLE
REAMDE: Remove leftover Setext-style markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # OCI systemd hooks
-==============
 
 OCI systemd hook enables users to run systemd in docker and [OCI](https://github.com/opencontainers/specs) compatible runtimes such as runc without requiring `--privileged` flag.
 


### PR DESCRIPTION
In 7ac5d7a7 (2015-11-23), we added atx-style markup for this header but neglegted to remove the Setext-style markup.  Both styles are discussed [here][1].

[1]: https://daringfireball.net/projects/markdown/syntax#header