### PR TITLE
README: Update OCI runtime spec link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OCI systemd hooks
 
-OCI systemd hook enables users to run systemd in docker and [OCI](https://github.com/opencontainers/specs) compatible runtimes such as runc without requiring `--privileged` flag.
+OCI systemd hook enables users to run systemd in docker and [OCI][] compatible runtimes such as runc without requiring `--privileged` flag.
 
 This project produces a C binary that can be used with runc and Docker (with minor code changes).
 If you clone this branch and build/install `oci-systemd-hook`, a binary should be placed in
@@ -96,3 +96,5 @@ autoreconf -i
 make
 make install
 ```
+
+[OCI]: https://github.com/opencontainers/runtime-spec


### PR DESCRIPTION
The repository was renamed specs -> runtime-spec when the OCI added the image-spec project as a separate repository.

Also convert this to a reference-style link to make the text easier to read (no inline URL clutter) and the link easier to update (no surrounding English clutter).