### PR TITLE
Do not touch the parent directory

### DIFF
--- a/src/systemdhook.c
+++ b/src/systemdhook.c
@@ -156,6 +156,10 @@ static int chperm(const char *id, const char *path, const char *label, uint uid,
 	if ((dir = opendir (path)) != NULL) {
 		/* print all the files and directories within directory */
 		while ((ent = readdir (dir)) != NULL) {
+			if (!strcmp("..", ent->d_name)) {
+				// Do not touch the parent directory
+				continue;
+			}
 			_cleanup_free_ char *full_path = NULL;
 			if (asprintf(&full_path, "%s/%s", path, ent->d_name) < 0) {
 				pr_perror("%s: Failed to create path for chperm", id);


### PR DESCRIPTION
The current version of the oci-systemd-hooks changes the SELinux context of the /sys/fs/cgroup/systemd/system.slice directory on every launch of the systemd container, disrupting access to this directory for previously launched containers.

I checked it on a clean install of CentOS 7.6.
```
# yum -y update
# yum -y install docker
# systemctl start docker
# semanage boolean -m --on container_manage_cgroup
```

Default SELinux context on /sys/fs/cgroup/systemd/system.slice directory is system_u:object_r:cgroup_t:s0
```
# ls -dZ /sys/fs/cgroup/systemd/system.slice
drwxr-xr-x. root root system_u:object_r:cgroup_t:s0    /sys/fs/cgroup/systemd/system.slice
```

Now let's run our first container.
```
# docker run -d docker.io/alekseychudov/centos7-systemd
002fb057ce87c86732a1771c19d77407c2df23bff34c95041e3dd79b82267331

# docker inspect 002fb057ce87c86732a1771c19d77407c2df23bff34c95041e3dd79b82267331 | grep ProcessLabel
        "ProcessLabel": "system_u:system_r:svirt_lxc_net_t:s0:c214,c860",

# ls -dZ /sys/fs/cgroup/systemd/system.slice
drwxr-xr-x. root root system_u:object_r:container_file_t:s0:c214,c860 /sys/fs/cgroup/systemd/system.slice
```

The context has changed to the current context of the container. Let's try to launch the second container.
```
# docker run -d docker.io/alekseychudov/centos7-systemd
4547fe3ba2feec1939efb17483433f2ac220a998cded501c33906d26f5e890a3

# docker inspect 4547fe3ba2feec1939efb17483433f2ac220a998cded501c33906d26f5e890a3 | grep ProcessLabel
        "ProcessLabel": "system_u:system_r:svirt_lxc_net_t:s0:c35,c196",

# ls -dZ /sys/fs/cgroup/systemd/system.slice
drwxr-xr-x. root root system_u:object_r:container_file_t:s0:c35,c196 /sys/fs/cgroup/systemd/system.slice
```

The context has changed to the context of the second container, and the first container has lost access to the cgroup hierarchy.
```
# docker exec -it 002fb057ce87c86732a1771c19d77407c2df23bff34c95041e3dd79b82267331 ls -l /sys/fs/cgroup/systemd/system.slice
ls: cannot open directory /sys/fs/cgroup/systemd/system.slice: Permission denied
```

I added debug output to oci-systemd-hook. So we can see what happens with SELinux context.
```
...
002fb057ce87: DEBUG set context system_u:object_r:svirt_sandbox_file_t:s0:c214,c860 on /sys/fs/cgroup/systemd/system.slice/docker-002fb057ce87c86732a1771c19d77407c2df23bff34c95041e3dd79b82267331.scope/..
...
4547fe3ba2fe: DEBUG set context system_u:object_r:svirt_sandbox_file_t:s0:c35,c196 on /sys/fs/cgroup/systemd/system.slice/docker-4547fe3ba2feec1939efb17483433f2ac220a998cded501c33906d26f5e890a3.scope/..
...
```

So, the problem is in the chperm() function, readdir() returns parent directory ".." and we should exclude it.